### PR TITLE
gts4lv/gts4lvwifi: Add to build server

### DIFF
--- a/build_targets
+++ b/build_targets
@@ -1,6 +1,8 @@
 # crDroid build target list
 # <device> <build_type> <auto-upload>
 beryllium userdebug yes
+gts4lv user no
+gts4lvwifi user no
 guacamole userdebug yes
 lemonade userdebug yes
 lemonadep userdebug yes


### PR DESCRIPTION
Building Samsung Galaxy Tab S5e WIFI and LTE variants.

Device trees:
https://github.com/crdroidandroid/android_device_samsung_gts4lv-common
https://github.com/crdroidandroid/android_device_samsung_gts4lvwifi
https://github.com/crdroidandroid/android_device_samsung_gts4lv


