### PR TITLE
kane: Add to the roaser

### DIFF
--- a/build_targets
+++ b/build_targets
@@ -2,5 +2,6 @@
 # <device> <build_type> <auto-upload>
 beryllium userdebug yes
 guacamole userdebug yes
+kane userdebug yes
 lemonade userdebug yes
 lemonadep userdebug yes


### PR DESCRIPTION
Adding Motorola Moto One Vision to the build roaster

Device tree link:
https://github.com/crdroidandroid/android_device_motorola_kane