### PR TITLE
Add a52q and a72q build targets.

### DIFF
--- a/build_targets
+++ b/build_targets
@@ -1,7 +1,9 @@
 # crDroid build target list
 # <device> <build_type> <auto-upload> <saveimages>
+a52q userdebug yes [recovery.img]
 a52sxq userdebug yes [boot.img, recovery.img]
 a71 userdebug yes [boot.img, dtbo.img]
+a72q userdebug yes [recovery.img]
 a73xq user yes [recovery.img]
 aston userdebug yes [boot.img, dtbo.img, init_boot.img, recovery.img, vbmeta.img, vendor_boot.img]
 avalon userdebug yes [boot.img, dtbo.img, init_boot.img, recovery.img, vbmeta.img, vendor_boot.img]


### PR DESCRIPTION
building with just "brunch a52q" (or a72q) has been tested and trees have been adapted for QPR1.