### PR TITLE
build_targets: Add OnePlus Ace 5

### DIFF
--- a/build_targets
+++ b/build_targets
@@ -20,6 +20,7 @@ dodge userdebug yes [boot.img, dtbo.img, init_boot.img, recovery.img, vbmeta.img
 erhai userdebug yes [boot.img, dtbo.img, init_boot.img, recovery.img, vbmeta.img, vendor_boot.img]
 fogo userdebug no [boot.img, dtbo.img, vendor_boot.img]
 giulia userdebug yes [boot.img, dtbo.img, init_boot.img, recovery.img, vbmeta.img, vendor_boot.img]
+giuliac userdebug yes [boot.img, dtbo.img, init_boot.img, recovery.img, vbmeta.img, vendor_boot.img]
 guacamole userdebug yes [boot.img]
 kebab userdebug yes [recovery.img]
 komodo userdebug yes [boot.img, dtbo.img, init_boot.img, vendor_boot.img, vendor_kernel_boot.img]


### PR DESCRIPTION
This is now separated from OnePlus 13R.